### PR TITLE
Ensure not ready before initialization completes

### DIFF
--- a/bin/postgres/readiness.sh
+++ b/bin/postgres/readiness.sh
@@ -17,4 +17,4 @@ source /opt/cpm/bin/common_lib.sh
 enable_debugging
 source /opt/cpm/bin/setenv.sh
 
-$PGROOT/bin/psql -f /opt/cpm/bin/readiness.sql -U $PG_USER postgres
+PGPASSWORD=$(</pgroot/password) $PGROOT/bin/psql -f /opt/cpm/bin/readiness.sql -h localhost -U "$(</pgroot/username)"  postgres

--- a/bin/postgres/start.sh
+++ b/bin/postgres/start.sh
@@ -305,13 +305,11 @@ function initialize_primary() {
         echo "Starting database.." >> /tmp/start-db.log
 
         echo_info "Temporarily starting database to run setup.sql.."
-        pg_ctl -D $PGDATA start
+        pg_ctl -o '-h ""' -D $PGDATA start
 
         echo_info "Waiting for PostgreSQL to start.."
         while true; do
             pg_isready \
-            --port=$PG_PRIMARY_PORT \
-            --host=$HOSTNAME \
             --username=$PG_PRIMARY_USER \
             --timeout=2
             if [ $? -eq 0 ]; then


### PR DESCRIPTION
The script starts Postgres up to run a setup script. During that time, postgres is listening on 0.0.0.0 (the default) and the readiness script runs a `psql` command using the unix socket. By _not_ listening on any network interface and changing the readiness script to only use the loopback interface, setup will proceed without allowing connections from outside which can interfere with setup and also cause the database to appear ready but unusable. It also avoids the situation where the database appears available, then briefly unavailable, and available again, which happens because the database restarts after setup.

Fixes ENG-596